### PR TITLE
Add canonical link

### DIFF
--- a/helpers/application_helpers.rb
+++ b/helpers/application_helpers.rb
@@ -15,6 +15,11 @@ module ApplicationHelpers
     markdown.render(contents)
   end
 
+  def preferred_url
+    path = yield_content :preferred_path
+    File.join(ENV["SITE_URL"], path, "/")
+  end
+
   def svg(name)
     root = Middleman::Application.root
     file_path = "#{root}/source/images/#{name}.svg"

--- a/source/docs/version/index.html.slim
+++ b/source/docs/version/index.html.slim
@@ -1,4 +1,5 @@
 - content_for(:title, "Bourbon Documentation | #{version}")
+- content_for(:preferred_path, "docs/#{version}")
 
 section
   .container

--- a/source/layouts/layout.slim
+++ b/source/layouts/layout.slim
@@ -5,13 +5,15 @@ html lang="en"
     meta(name="viewport"
          content="width=device-width, initial-scale=1, shrink-to-fit=no")
     - if content_for?(:description)
-      meta name="description" content=(yield_content :description)
+      meta name="description" content=yield_content :description
     - else
       meta name="description" content="Bourbon is a…"
     - if content_for?(:title)
-      title=(yield_content :title)
+      title=yield_content :title
     - else
       title="Bourbon"
+    - if content_for?(:preferred_path)
+      link rel="canonical" href=preferred_url
     = stylesheet_link_tag :main
   body
     = partial "partials/site_nav"


### PR DESCRIPTION
This allows us to specify a canonical link when we have duplicate content, e.g. `/docs/latest/` is a duplicate of `/docs/[latest_version]/`.
