### PR TITLE
Use a helper to build GitHub source url's

### DIFF
--- a/helpers/application_helpers.rb
+++ b/helpers/application_helpers.rb
@@ -1,4 +1,8 @@
 module ApplicationHelpers
+  def github_file_url(file_path, version)
+    "https://github.com/thoughtbot/bourbon/blob/v#{version}/core/#{file_path}"
+  end
+
   def markdown(contents)
     renderer = Redcarpet::Render::HTML
     markdown = Redcarpet::Markdown.new(

--- a/source/docs/version/index.html.slim
+++ b/source/docs/version/index.html.slim
@@ -17,7 +17,8 @@ div.p-container.p-flex-container
   section.c-docs-list
     - version.doc_items.each do |item|
       article.c-doc-item id="#{item.context.name}"
-        = partial "partials/doc_item_header", locals: { item: item }
+        = partial "partials/doc_item_header",
+                  locals: { item: item, version: version }
         - if item.parameter.present?
           = partial "partials/doc_item_arguments", locals: { item: item }
         - if item.example.present?

--- a/source/partials/_doc_item_header.slim
+++ b/source/partials/_doc_item_header.slim
@@ -10,8 +10,7 @@ span.doc-item__directive-type
     | Returns: #{ item.return.type }
 
 div.doc-item__source-link
-  = link_to "View Source",
-            "//github.com/thoughtbot/bourbon/blob/master/core/#{item.file.path}"
+  = link_to "View Source", github_file_url(item.file.path, version)
 
 - if item.description.present?
   div.doc-item__description


### PR DESCRIPTION
This allows the `View Source` link to always point to the same version
you're viewing the docs in.
