### PR TITLE
Remove unused font

### DIFF
--- a/source/assets/stylesheets/library/_variables.scss
+++ b/source/assets/stylesheets/library/_variables.scss
@@ -10,7 +10,7 @@ $large-screen: 900px;
 
 // Typography
 $base-font-family: $font-stack-system;
-$heading-font-family: "Quincy", $font-stack-georgia;
+$heading-font-family: $base-font-family;
 
 // Font Sizes
 $base-font-size: 0.875em;


### PR DESCRIPTION
We don’t have Quincy available yet, so let’s remove the declaration until the web font available.
