### PR TITLE
Add content columns to homepage

### DIFF
--- a/source/assets/stylesheets/components/_docs-list.scss
+++ b/source/assets/stylesheets/components/_docs-list.scss
@@ -1,3 +1,3 @@
 .c-docs-list {
-  @include grid-column(9);
+  @include grid-column(6);
 }

--- a/source/assets/stylesheets/patterns/_column.scss
+++ b/source/assets/stylesheets/patterns/_column.scss
@@ -1,0 +1,7 @@
+.p-column--6 {
+  @include grid-column(6);
+}
+
+.p-column--push-3 {
+  @include grid-push(3);
+}

--- a/source/assets/stylesheets/patterns/_container.scss
+++ b/source/assets/stylesheets/patterns/_container.scss
@@ -1,5 +1,5 @@
 .p-container {
   @include grid-container;
   @include margin(null auto);
-  max-width: 60rem;
+  max-width: 88rem;
 }

--- a/source/assets/stylesheets/patterns/_patterns.scss
+++ b/source/assets/stylesheets/patterns/_patterns.scss
@@ -1,1 +1,2 @@
 @import "container";
+@import "column";

--- a/source/index.html.slim
+++ b/source/index.html.slim
@@ -1,76 +1,81 @@
 header
   div.p-container
-    h1 Bourbon
-    h2
-      | A Lightweight Sass Tool&nbsp;Set
-    nav role="navigation"
-      = link_to "Documentation",
-        "/docs/latest/",
-        class: "c-button"
-    ul
-      li
-        | File bugs and questions on
-          #{link_to "GitHub", "https://github.com/thoughtbot/bourbon"}.
-      li
-        | Find feature and API changes in the
-          #{link_to "change log", "/changelog/"}.
-      li
-        | Follow us on
-          #{link_to "Twitter", "https://twitter.com/bourbonsass"}
-          for announcements.
+    .p-column--6.p-column--push-3
+      h1 Bourbon
+      h2
+        | A Lightweight Sass Tool&nbsp;Set
+      nav role="navigation"
+        = link_to "Documentation",
+          "/docs/latest/",
+          class: "c-button"
+      ul
+        li
+          | File bugs and questions on
+            #{link_to "GitHub", "https://github.com/thoughtbot/bourbon"}.
+        li
+          | Find feature and API changes in the
+            #{link_to "change log", "/changelog/"}.
+        li
+          | Follow us on
+            #{link_to "Twitter", "https://twitter.com/bourbonsass"}
+            for announcements.
 
 section
   div.p-container
-    h3
-      | Make something great
-    p
-      span.c-emoji
-        ' 😍
-      br
-      | Bourbon is a tool for making awesome projects
-        on the web from the designers and developers
-        at #{link_to "thoughtbot", "https://thoughtbot.com"}.
-    p
-      | With tools like color functions, animation
-        timing functions, CSS triangles, input variables
-        and more, Bourbon helps you write less Sass
-        so you can focus on your project instead of
-        your stylesheets.
+    .p-column--6.p-column--push-3
+      h3
+        | Make something great
+      p
+        span.c-emoji
+          ' 😍
+        br
+        | Bourbon is a tool for making awesome projects
+          on the web from the designers and developers
+          at #{link_to "thoughtbot", "https://thoughtbot.com"}.
+      p
+        | With tools like color functions, animation
+          timing functions, CSS triangles, input variables
+          and more, Bourbon helps you write less Sass
+          so you can focus on your project instead of
+          your stylesheets.
 
 section
   div.p-container
-    h3
-      | Lots of awesome projects  use Bourbon
-    ul
-      li
-        | The U.S. Web Design Standards
-    p
-      | Are you using Bourbon? Let us know!
+    .p-column--6.p-column--push-3
+      h3
+        | Lots of awesome projects  use Bourbon
+      ul
+        li
+          | The U.S. Web Design Standards
+      p
+        | Are you using Bourbon? Let us know!
 
 section
   div.p-container
-    h3
-      | Welcome to the family
-    p
-      span.c-emoji
-        ' 👋
-      br
-      | Bourbon also works great with Neat, Bitters,
-        and Refills. They are all lightweight and
-        easy to work with so it’s a blast to try
-        them out and see if they’re right for your
-        next project.
+    .p-column--6.p-column--push-3
+      h3
+        | Welcome to the family
+      p
+        span.c-emoji
+          ' 👋
+        br
+        | Bourbon also works great with Neat, Bitters,
+          and Refills. They are all lightweight and
+          easy to work with so it’s a blast to try
+          them out and see if they’re right for your
+          next project.
 
 footer
   div.p-container
-    p
-      | Bourbon is maintained and funded with
-      span.c-emoji
-        '  💖
-      | from the humans at #{link_to "thoughtbot", "https://thoughtbot.com"}.
-    p
-      | Bourbon is free software, and may be
-        redistributed under the terms specified in the
-        #{ link_to "license", "https://github.com/thoughtbot/bourbon/blob/master/LICENSE.md"}.
-    p
-      | &#169; 2011 #{link_to "thoughtbot, inc.", "https://thoughtbot.com"}
+    .p-column--6.p-column--push-3
+      p
+        | Bourbon is maintained and funded with
+        span.c-emoji
+          '  💖
+        | from the humans at #{link_to "thoughtbot", "https://thoughtbot.com"}.
+      p
+        | Bourbon is free software, and may be
+          redistributed under the terms specified in the
+          #{ link_to "license", "https://github.com/thoughtbot/bourbon/blob/master/LICENSE.md"}.
+      p
+        | &#169; 2011 #{link_to "thoughtbot, inc.", "https://thoughtbot.com"}


### PR DESCRIPTION
This change slims down the columns a bit, but also makes better use of neat. I added some simple grid classes. I think given our simple layouts, this will probably be better than dreaming up some esoteric class name like… `.centered-content-something-something`.

Anywho, I increased the `max-width` of the container to ~1400px and in tern adjusted the proportional width of the docs nav and content accordingly. one cool aspect of this is that it makes a 3-col, 6-col, 3-col layout which looks nice but also allows us to place content on the right sidebar at some point in the future, see https://sample-threes.readme.io

All in all this change brings the overall look and proportion more in line with some of the visual references that @tysongach and I have been using as inspiration including other open source projects.
