### PR TITLE
Reduce spacing after headings

### DIFF
--- a/source/assets/stylesheets/base/_typography.scss
+++ b/source/assets/stylesheets/base/_typography.scss
@@ -15,7 +15,7 @@ h6 {
   font-size: modular-scale(1);
   font-weight: 400;
   line-height: $heading-line-height;
-  margin: 0 0 $small-spacing;
+  margin: 0 0 $heading-spacing;
 }
 
 h1 {

--- a/source/assets/stylesheets/library/_variables.scss
+++ b/source/assets/stylesheets/library/_variables.scss
@@ -26,6 +26,7 @@ $small-spacing: $base-spacing / 2;
 $base-z-index: 0;
 $letter-spacing-small: 0.02em;
 $letter-spacing-extra-small: $letter-spacing-small / 2;
+$heading-spacing: 1rem;
 
 // Grid
 $neat-grid: (


### PR DESCRIPTION
<img width="1440" alt="screen shot 2016-07-16 at 4 33 15 pm" src="https://cloud.githubusercontent.com/assets/2489247/16897313/6ee47376-4b7b-11e6-9f67-bbbe6e49bd7c.png">
### and now…

<img width="1440" alt="screen shot 2016-07-16 at 5 33 03 pm" src="https://cloud.githubusercontent.com/assets/2489247/16897316/8566d99a-4b7b-11e6-83d1-937be310ddc6.png">

Still by no means perfect, but better since before a given heading was closer to the content above it than to the content is describing.
