### PR TITLE
Add note for where to find the library code

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,11 @@
 
 This is the source code for the [Bourbon website]. It’s built with [Middleman].
 
+You can find the [Bourbon Sass library source code here][library repo].
+
 [Bourbon website]: http://www.bourbon.io/
 [Middleman]: https://middlemanapp.com/
+[library repo]: https://github.com/thoughtbot/bourbon
 
 ## Setup
 


### PR DESCRIPTION
We’ve had some folks get confused that this wasn’t the repo for the library itself: https://github.com/thoughtbot/bourbon.io/issues/5.
