### PR TITLE
Add AccessLint CI to run accessibility tests in CI builds

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,18 @@
-test:
+general:
+  artifacts:
+    - "tmp"
+
+dependencies:
+  post:
+    - npm install -g accesslint-cli
+    - gem install accesslint-ci
+
+compile:
   override:
     - bundle exec middleman build --verbose
+
+test:
+  override:
+    - |
+      bundle exec middleman server --daemon --port=4567 --watcher-disable && \
+      accesslint-ci scan http://localhost:4567


### PR DESCRIPTION
- Runs accesslint on the entire site for new pull requests and comments
  on the PR with accessibility issues.
- CI will *not* fail on accessibility errors. It will comment only.
- The first PR with this change will list all of the accessibility
  issues on the site.
- Subsequent PRs will only receive comments there are new changes.

### Requirements

- Add @accesslint-ci to as a collaborator on the project
- Needs these environment variables set in CI:
  - CIRCLE_TOKEN
  - ACCESSLINT_GITHUB_TOKEN