### PR TITLE
Update accesslint-ci dependency and config

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,3 +16,7 @@ gem "sassc"
 gem "scss_lint", "0.49.0", require: false
 gem "slim"
 gem "slim_lint", require: false
+
+group :development, :test do
+  gem "accesslint-ci", "~> 0.2"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,9 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    accesslint-ci (0.2.3)
+      rest-client (~> 2.0)
+      thor (~> 0.19)
     activesupport (4.2.7.1)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
@@ -24,6 +27,8 @@ GEM
       sass (>= 3.2, < 3.5)
     concurrent-ruby (1.0.2)
     contracts (0.13.0)
+    domain_name (0.5.20161129)
+      unf (>= 0.0.5, < 1.0.0)
     dotenv (2.1.1)
     em-websocket (0.5.1)
       eventmachine (>= 0.12.9)
@@ -41,6 +46,8 @@ GEM
       concurrent-ruby (~> 1.0)
     hashie (3.4.4)
     htmlcompressor (0.2.0)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
     http_parser.rb (0.6.0)
     i18n (0.7.0)
     json (1.8.3)
@@ -95,10 +102,14 @@ GEM
     middleman-syntax (2.1.0)
       middleman-core (>= 3.2)
       rouge (~> 1.0)
+    mime-types (3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2016.0521)
     minitest (5.9.0)
     neat (2.0.0.beta.1)
       sass (~> 3.4)
       thor (~> 0.19)
+    netrc (0.11.0)
     padrino-helpers (0.13.3)
       i18n (~> 0.6, >= 0.6.7)
       padrino-support (= 0.13.3)
@@ -118,6 +129,10 @@ GEM
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
     redcarpet (3.3.4)
+    rest-client (2.0.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rouge (1.11.1)
     rubocop (0.41.2)
       parser (>= 2.3.1.1, < 3.0)
@@ -152,12 +167,16 @@ GEM
       thread_safe (~> 0.1)
     uglifier (3.0.2)
       execjs (>= 0.3.0, < 3)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.2)
     unicode-display_width (1.1.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  accesslint-ci (~> 0.2)
   bourbon (~> 5.0.0.beta.7)
   builder
   middleman (~> 4.1)

--- a/circle.yml
+++ b/circle.yml
@@ -2,10 +2,13 @@ general:
   artifacts:
     - "tmp"
 
+machine:
+  node:
+    version: 6.1.0
+
 dependencies:
   post:
     - npm install -g accesslint-cli
-    - gem install accesslint-ci
 
 compile:
   override:
@@ -15,4 +18,4 @@ test:
   override:
     - |
       bundle exec middleman server --daemon --port=4567 --watcher-disable && \
-      accesslint-ci scan http://localhost:4567
+      bundle exec accesslint-ci scan http://localhost:4567


### PR DESCRIPTION
- Specify a version with bundler via the Gemfile.
- Use the correct version of node required by accesslint-cli.