### PR TITLE
Use Netlify's new structured redirect rules

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -55,8 +55,6 @@ proxy(
   ignore: true,
 )
 
-proxy("_redirects", "netlify_redirects", ignore: true)
-
 if defined? RailsAssets
   RailsAssets.load_paths.each do |path|
     sprockets.append_path path

--- a/source/netlify.toml
+++ b/source/netlify.toml
@@ -1,0 +1,4 @@
+[[redirects]]
+  from = "/docs"
+  to = "/docs/latest"
+  status = 301

--- a/source/netlify_redirects
+++ b/source/netlify_redirects
@@ -1,1 +1,0 @@
-/docs/ /docs/latest/ 301


### PR DESCRIPTION
This allows us to get around the hack we had in place to create a `_redirects` file at the root of the project. More on that here: https://github.com/thoughtbot/bourbon.io/commit/541007c9e0743f98bfd712bd9fbfc4c6e52e966d

Structured rules announcement: https://www.netlify.com/blog/2017/10/17/introducing-structured-redirects-and-headers/

Structured rules docs: https://www.netlify.com/docs/redirects/#structured-configuration