### PR TITLE
Swap segment for google tag manager

### DIFF
--- a/source/partials/_analytics.erb
+++ b/source/partials/_analytics.erb
@@ -1,8 +1,9 @@
-<% if ENV["SEGMENT_KEY"] %>
+<% if ENV["GTM_CONTAINER_ID"] %>
   <script>
-    !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t){var e=document.createElement("script");e.type="text/javascript";e.async=!0;e.src=("https:"===document.location.protocol?"https://":"http://")+"cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(e,n)};analytics.SNIPPET_VERSION="4.0.0";
-    analytics.load("<%= ENV["SEGMENT_KEY"] %>");
-    analytics.page();
-    }}();
+    (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','<%= ENV["GTM_CONTAINER_ID"] %>');
   </script>
 <% end %>


### PR DESCRIPTION
Previously we were doing:

```
segment → google analytics
        ↳ google tag manager
```

we now do 

```
segment → google tag manager → google analytics
```

This change will now simplify the process to

```
google tag manager → google analytics
```

Just removing some unnecessary complexity.

`GTM_CONTAINER_ID` has been added to deploy env